### PR TITLE
Fix backwards dragged ranges.

### DIFF
--- a/OCCalendarView/OCCalendarViewController.m
+++ b/OCCalendarView/OCCalendarViewController.m
@@ -70,7 +70,10 @@
     [calView removeFromSuperview];
     calView = nil;
     
-    [self.delegate completedWithStartDate:startDate endDate:endDate];
+    if([startDate compare:endDate] == NSOrderedAscending)
+        [self.delegate completedWithStartDate:startDate endDate:endDate];
+    else
+        [self.delegate completedWithStartDate:endDate endDate:startDate];
 }
 
 

--- a/OCCalendarView/OCSelectionView.m
+++ b/OCCalendarView/OCSelectionView.m
@@ -64,13 +64,19 @@
             int thisRowStartCell;
             if(startCellY == i) {
                 thisRowStartCell = startCellX;
+                if (startCellY > endCellY) {
+                    thisRowStartCell = 0; thisRowEndCell = startCellX;
+                }
             } else {
                 thisRowStartCell = 0;
             }
             
             if(endCellY == i) {
                 thisRowEndCell = endCellX;
-            } else {
+                if (startCellY > endCellY) {
+                    thisRowStartCell = endCellX; thisRowEndCell = 6;
+                }
+            } else if (!(startCellY > endCellY)) {
                 thisRowEndCell = 6;
             }
             


### PR DESCRIPTION
If you dragged backwards and spanned weeks it highlighted the wrong dates.  Also always return date range in ascending order.
